### PR TITLE
Add modern Next.js starter

### DIFF
--- a/modern-notes/.env.local.example
+++ b/modern-notes/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://api.pylypenko.dev
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/modern-notes/README.md
+++ b/modern-notes/README.md
@@ -1,0 +1,15 @@
+# Modern Notes
+
+A minimal Next.js starter for taking notes. Includes sample pages for a dashboard, editor, and authentication.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.local.example` to `.env.local` and fill in your Supabase credentials.
+3. Run the dev server:
+   ```bash
+   npm run dev
+   ```

--- a/modern-notes/next-env.d.ts
+++ b/modern-notes/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/modern-notes/next.config.js
+++ b/modern-notes/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/modern-notes/package.json
+++ b/modern-notes/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "modern-notes",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.39.5",
+    "clsx": "1.2.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.4",
+    "@types/react": "18.2.24",
+    "@types/node": "20.11.18",
+    "typescript": "5.4.3"
+  }
+}

--- a/modern-notes/postcss.config.js
+++ b/modern-notes/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/modern-notes/src/app/dashboard/page.tsx
+++ b/modern-notes/src/app/dashboard/page.tsx
@@ -1,0 +1,27 @@
+import { sampleNotes } from '../../lib/sample-notes'
+import NoteCard from '../../components/NoteCard'
+import Button from '../../components/ui/Button'
+import Link from 'next/link'
+
+export default function Dashboard() {
+  const notes = sampleNotes
+  return (
+    <main className="p-6 max-w-3xl mx-auto space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Your Notes</h1>
+        <Link href="/note/new">
+          <Button>New Note</Button>
+        </Link>
+      </div>
+      {notes.length === 0 ? (
+        <p className="text-gray-500">No notes yet. Start by creating one!</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {notes.map((note) => (
+            <NoteCard key={note.id} note={note} />
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/modern-notes/src/app/globals.css
+++ b/modern-notes/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-900 antialiased;
+}

--- a/modern-notes/src/app/layout.tsx
+++ b/modern-notes/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css'
+import { ReactNode } from 'react'
+
+export const metadata = {
+  title: 'Modern Notes',
+  description: 'A minimal note taking app',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex flex-col">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/modern-notes/src/app/login/page.tsx
+++ b/modern-notes/src/app/login/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { useState } from 'react'
+import Button from '../../components/ui/Button'
+import { useRouter } from 'next/navigation'
+
+export default function Login() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // Placeholder login
+    router.push('/dashboard')
+  }
+
+  return (
+    <main className="flex items-center justify-center h-screen p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-lg shadow w-full max-w-sm">
+        <h1 className="text-2xl font-bold text-center">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="w-full p-2 border rounded"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="w-full p-2 border rounded"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <Button className="w-full" type="submit">Sign In</Button>
+      </form>
+    </main>
+  )
+}

--- a/modern-notes/src/app/note/[id]/page.tsx
+++ b/modern-notes/src/app/note/[id]/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { sampleNotes, Note } from '../../../lib/sample-notes'
+import Button from '../../../components/ui/Button'
+
+interface Params { params: { id: string } }
+
+export default function NoteEditor({ params }: Params) {
+  const router = useRouter()
+  const existing = sampleNotes.find(n => n.id === params.id)
+  const [title, setTitle] = useState(existing?.title || '')
+  const [content, setContent] = useState(existing?.content || '')
+
+  const handleSave = () => {
+    // Placeholder save logic
+    alert('Saved!')
+    router.push('/dashboard')
+  }
+
+  return (
+    <main className="p-6 max-w-3xl mx-auto space-y-4">
+      <input
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        placeholder="Title"
+        className="w-full p-2 text-2xl font-bold border-b focus:outline-none"
+      />
+      <textarea
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        placeholder="Start writing..."
+        className="w-full h-72 p-2 border rounded-md focus:outline-none"
+      />
+      <Button onClick={handleSave}>Save</Button>
+    </main>
+  )
+}

--- a/modern-notes/src/app/note/new/page.tsx
+++ b/modern-notes/src/app/note/new/page.tsx
@@ -1,0 +1,3 @@
+import NoteEditor from '../[id]/page'
+
+export default NoteEditor

--- a/modern-notes/src/app/page.tsx
+++ b/modern-notes/src/app/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+import Button from '../components/ui/Button'
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center justify-center flex-1 p-8 text-center gap-4">
+      <h1 className="text-4xl font-bold mb-4">Modern Notes</h1>
+      <p className="text-gray-600 mb-8">A simple place to jot down your thoughts.</p>
+      <Link href="/dashboard">
+        <Button>Go to Dashboard</Button>
+      </Link>
+    </main>
+  )
+}

--- a/modern-notes/src/app/register/page.tsx
+++ b/modern-notes/src/app/register/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { useState } from 'react'
+import Button from '../../components/ui/Button'
+import { useRouter } from 'next/navigation'
+
+export default function Register() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // Placeholder register
+    router.push('/dashboard')
+  }
+
+  return (
+    <main className="flex items-center justify-center h-screen p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-lg shadow w-full max-w-sm">
+        <h1 className="text-2xl font-bold text-center">Register</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="w-full p-2 border rounded"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="w-full p-2 border rounded"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <Button className="w-full" type="submit">Create Account</Button>
+      </form>
+    </main>
+  )
+}

--- a/modern-notes/src/app/supabaseClient.ts
+++ b/modern-notes/src/app/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/modern-notes/src/components/NoteCard.tsx
+++ b/modern-notes/src/components/NoteCard.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+import { Note } from '../lib/sample-notes'
+
+interface Props {
+  note: Note
+}
+
+export default function NoteCard({ note }: Props) {
+  return (
+    <Link href={`/note/${note.id}`}
+      className="block p-4 rounded-lg shadow hover:shadow-md transition bg-white">
+      <h3 className="font-semibold text-lg mb-1">{note.title}</h3>
+      <p className="text-sm text-gray-600 truncate">{note.content}</p>
+    </Link>
+  )
+}

--- a/modern-notes/src/components/ui/Button.tsx
+++ b/modern-notes/src/components/ui/Button.tsx
@@ -1,0 +1,19 @@
+import { ButtonHTMLAttributes, FC } from 'react'
+import clsx from 'clsx'
+
+const Button: FC<ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  className,
+  ...props
+}) => {
+  return (
+    <button
+      className={clsx(
+        'rounded-md bg-black text-white px-4 py-2 hover:bg-gray-800 transition',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export default Button

--- a/modern-notes/src/components/ui/Spinner.tsx
+++ b/modern-notes/src/components/ui/Spinner.tsx
@@ -1,0 +1,5 @@
+export default function Spinner() {
+  return (
+    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900" />
+  )
+}

--- a/modern-notes/src/lib/sample-notes.ts
+++ b/modern-notes/src/lib/sample-notes.ts
@@ -1,0 +1,23 @@
+export interface Note {
+  id: string
+  title: string
+  content: string
+}
+
+export const sampleNotes: Note[] = [
+  {
+    id: '1',
+    title: 'First Note',
+    content: 'This is an example note.'
+  },
+  {
+    id: '2',
+    title: 'Another Note',
+    content: 'More sample content goes here.'
+  },
+  {
+    id: '3',
+    title: 'Last Note',
+    content: 'Final sample note.'
+  }
+]

--- a/modern-notes/tailwind.config.js
+++ b/modern-notes/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/app/**/*.{js,ts,jsx,tsx}',
+    './src/components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/modern-notes/tsconfig.json
+++ b/modern-notes/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js app router project under `modern-notes`
- include sample dashboard, note editor, login and register pages
- include Tailwind setup and sample notes
- configure Supabase client via environment variables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856b9e664ac8327a426b31c5e6f59e1